### PR TITLE
Updates for PyPI Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,73 @@
+# autobahn-autoreconnect
+Python Autobahn runner with auto-reconnect feature
+
+## Installation
+```bash
+$pip install autobahn-autoreconnect 
+```
+
+## Dependencies
+autobahn >= 14.0.0
+
+## Usage
+Just import the `ApplicationRunner` from `autobahn_autoreconnect` and it works as a drop in replacement for
+`autobahn.asyncio.wamp.Application Runner`.
+
+```python
+from autobahn.asyncio.wamp import ApplicationSession
+# from autobahn.asyncio.wamp import ApplicationRunner
+from autobahn_autoreconnect import ApplicationRunner
+
+
+class MyComponent(ApplicationSession):
+    # awsesome wamp stuff 
+  
+if __name__ == '__main__':
+    runner = ApplicationRunner("ws://localhost:8080/ws", "realm1")
+    runner.run(MyComponent)
+```
+
+### Retry Strategy
+The default retry strategy is the `BackoffStrategy` based on an increasing time interval starting at 0.5 seconds and doubling 
+until a maximum of 512 seconds before giving up. If you want to override the defaults you can pass in your own `BackoffStrategy` like so:
+
+```python
+from autobahn_autoreconnect import BackoffStrategy
+
+# start with a 10s delay and increase by a factor of 10 until 1000s
+# This strategy will wait 10s, 100s and 1000s and then stop retrying
+strategy = BackoffStrategy(initial_interval=10, max_interval=1000 factor=10)
+runner = ApplicationRunner("ws://localhost:8080/ws", "realm1", retry_strategy=strategy)
+```
+
+### Custom Retry Strategies
+You can also implement you own retry class by inheriting from `autobahn_autoreconnect.IReconnectStrategy`.
+
+For example, to retry every second for 100 seconds we could do something like:
+
+```python
+from autobahn_autoreconnect import IReconnectStrategy
+
+class OneSecondStrategy(IReconnectStrategy):
+
+    def __init__(self):
+        self._retry_counter = 0
+  
+    def get_retry_interval(self):
+        """Return interval, in seconds, to wait between retries"""
+        return 1 
+
+    def reset_retry_interval(self):
+        """Called before the first time we try to reconnect"""
+        self._retry_counter = 0
+
+    def increase_retry_interval(self):
+        """Called every time a retry attempt fails"""
+        self._retry_counter += 1
+    
+    def retry(self):
+        """Returning True will keep retrying, False will stop retrying"""
+        return self._retry_counter < 100
+        
+runner = ApplicationRunner("ws://localhost:8080/ws", "realm1", retry_strategy=OneSecondStrategy())
+```

--- a/example.py
+++ b/example.py
@@ -1,27 +1,26 @@
-import asyncio, os
+import os
 from autobahn.asyncio.wamp import ApplicationSession
 from autobahn_autoreconnect import ApplicationRunner
 
 class MyComponent(ApplicationSession):
-    @asyncio.coroutine
-    def onJoin(self, details):
+
+    async def onJoin(self, details):
         # listening for the corresponding message from the "backend"
         # (any session that .publish()es to this topic).
         def onevent(msg):
             print("Got event: {}".format(msg))
-        yield from self.subscribe(onevent, 'com.myapp.hello')
+        await self.subscribe(onevent, 'com.myapp.hello')
 
         # call a remote procedure.
-        res = yield from self.call('com.myapp.add2', 2, 3)
+        res = await self.call('com.myapp.add2', 2, 3)
         print("Got result: {}".format(res))
 
 
 if __name__ == '__main__':
     runner = ApplicationRunner(
-            os.environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
+        os.environ.get("AUTOBAHN_DEMO_ROUTER", "ws://localhost:8080/ws"),
         u"realm1",
-        debug_wamp=False,  # optional; log many WAMP details
-        debug=False,  # optional; log even more details
+        debug_app=False,  # optional; log even more details
     )
     runner.run(MyComponent)
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='autobahn-autoreconnect',
-    version='0.0.2',
+    version='0.0.3',
 
     description='Python Autobahn runner with auto-reconnect feature',
     url='https://github.com/isra17/autobahn-autoreconnect',
@@ -11,5 +11,5 @@ setup(
     license='LGPL2',
 
     packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
-    install_requires=['autobahn>=0.10.5']
+    install_requires=['autobahn>=0.14.0']
 )


### PR DESCRIPTION
Addresses everything in https://github.com/isra17/autobahn-autoreconnect/issues/7 (except the actual release to PyPI of course)
- Updated `example.py` to use the updated version of the code and python 3.5 `async/await`
- Updated setup.py 
  - updated minimum autobahn version to 0.14.0
  - bump 0.2.0 -> 0.3.0 
- Added README with some usage examples

Thanks a lot for your efforts on this. Hopefully this can help nudge out a new PyPI release. Let me know if there is anything you want me to change. Or if you want to do the readme and examples a different way thats cool too :)
